### PR TITLE
fix: stop running script as service worker

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,10 +7,6 @@
       "48": "icon48.png",
       "128": "icon128.png"
    },
-   "background": {
-      "service_worker": "services.js",
-      "type": "module"
-   },
    "content_scripts": [
       {
          "js": [


### PR DESCRIPTION
As far as I can tell, this does not require to be run separate from the UI thread. It can exist as a content script only. This caused issues as `MutationObserver` only exists in a UI context. Noticed when testing latest release.

![T49enfnw](https://github.com/michioxd/sounddark/assets/8437201/aad3a464-e673-4fcb-bb15-b965ac19cef2)
